### PR TITLE
ttfファイルがassets下にあるとき上手く配信されない問題の解消

### DIFF
--- a/shinchokunote/nginx.conf.yaml
+++ b/shinchokunote/nginx.conf.yaml
@@ -95,11 +95,20 @@ data:
         }
       }
 
-      # リストにないアドレスからのアクセスは444エラーで落とす
+      # リストにないアドレスからのアクセス
       server {
         listen       80  default_server;
         server_name  _;
-        return       444;
+
+        # health checkだけは許可
+        location = /health {
+          return 200;
+        }
+
+        # 444エラーで落とす
+        location / {
+          return 444;
+        }
       }
     }
   mime.types: |

--- a/shinchokunote/nginx.conf.yaml
+++ b/shinchokunote/nginx.conf.yaml
@@ -102,3 +102,100 @@ data:
         return       444;
       }
     }
+  mime.types: |
+    types {
+      text/html                                        html htm shtml;
+      text/css                                         css;
+      text/xml                                         xml;
+      image/gif                                        gif;
+      image/jpeg                                       jpeg jpg;
+      application/javascript                           js;
+      application/atom+xml                             atom;
+      application/rss+xml                              rss;
+
+      text/mathml                                      mml;
+      text/plain                                       txt;
+      text/vnd.sun.j2me.app-descriptor                 jad;
+      text/vnd.wap.wml                                 wml;
+      text/x-component                                 htc;
+
+      image/png                                        png;
+      image/svg+xml                                    svg svgz;
+      image/tiff                                       tif tiff;
+      image/vnd.wap.wbmp                               wbmp;
+      image/webp                                       webp;
+      image/x-icon                                     ico;
+      image/x-jng                                      jng;
+      image/x-ms-bmp                                   bmp;
+
+      font/woff                                        woff;
+      font/woff2                                       woff2;
+
+      application/java-archive                         jar war ear;
+      application/json                                 json;
+      application/mac-binhex40                         hqx;
+      application/msword                               doc;
+      application/pdf                                  pdf;
+      application/postscript                           ps eps ai;
+      application/rtf                                  rtf;
+      application/vnd.apple.mpegurl                    m3u8;
+      application/vnd.google-earth.kml+xml             kml;
+      application/vnd.google-earth.kmz                 kmz;
+      application/vnd.ms-excel                         xls;
+      application/vnd.ms-fontobject                    eot;
+      application/vnd.ms-powerpoint                    ppt;
+      application/vnd.oasis.opendocument.graphics      odg;
+      application/vnd.oasis.opendocument.presentation  odp;
+      application/vnd.oasis.opendocument.spreadsheet   ods;
+      application/vnd.oasis.opendocument.text          odt;
+      application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                      pptx;
+      application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                      xlsx;
+      application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                      docx;
+      application/vnd.wap.wmlc                         wmlc;
+      application/x-7z-compressed                      7z;
+      application/x-cocoa                              cco;
+      application/x-java-archive-diff                  jardiff;
+      application/x-java-jnlp-file                     jnlp;
+      application/x-makeself                           run;
+      application/x-perl                               pl pm;
+      application/x-pilot                              prc pdb;
+      application/x-rar-compressed                     rar;
+      application/x-redhat-package-manager             rpm;
+      application/x-sea                                sea;
+      application/x-shockwave-flash                    swf;
+      application/x-stuffit                            sit;
+      application/x-tcl                                tcl tk;
+      application/x-x509-ca-cert                       der pem crt;
+      application/x-xpinstall                          xpi;
+      application/xhtml+xml                            xhtml;
+      application/xspf+xml                             xspf;
+      application/zip                                  zip;
+
+      application/octet-stream                         bin exe dll;
+      application/octet-stream                         deb;
+      application/octet-stream                         dmg;
+      application/octet-stream                         iso img;
+      application/octet-stream                         msi msp msm;
+
+      audio/midi                                       mid midi kar;
+      audio/mpeg                                       mp3;
+      audio/ogg                                        ogg;
+      audio/x-m4a                                      m4a;
+      audio/x-realaudio                                ra;
+
+      video/3gpp                                       3gpp 3gp;
+      video/mp2t                                       ts;
+      video/mp4                                        mp4;
+      video/mpeg                                       mpeg mpg;
+      video/quicktime                                  mov;
+      video/webm                                       webm;
+      video/x-flv                                      flv;
+      video/x-m4v                                      m4v;
+      video/x-mng                                      mng;
+      video/x-ms-asf                                   asx asf;
+      video/x-ms-wmv                                   wmv;
+      video/x-msvideo                                  avi;
+    }

--- a/shinchokunote/nginx.conf.yaml
+++ b/shinchokunote/nginx.conf.yaml
@@ -198,4 +198,6 @@ data:
       video/x-ms-asf                                   asx asf;
       video/x-ms-wmv                                   wmv;
       video/x-msvideo                                  avi;
+
+      application/x-font-ttf                           ttf;
     }

--- a/shinchokunote/rails.yaml
+++ b/shinchokunote/rails.yaml
@@ -85,8 +85,7 @@ spec:
           - containerPort: 80
         volumeMounts:
           - name: nginx-conf
-            mountPath: /etc/nginx/nginx.conf
-            subPath: nginx.conf  # mount as a file(not directory)
+            mountPath: /etc/nginx
             readOnly: true
           - name: htpasswd
             mountPath: /etc/nginx/.htpasswd
@@ -108,6 +107,8 @@ spec:
             items:
               - key: nginx.conf
                 path: nginx.conf
+              - key: mime.types
+                path: mime.types
         - name: htpasswd
           secret:
             secretName: nginx

--- a/shinchokunote/rails.yaml
+++ b/shinchokunote/rails.yaml
@@ -85,7 +85,12 @@ spec:
           - containerPort: 80
         volumeMounts:
           - name: nginx-conf
-            mountPath: /etc/nginx
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf  # mount as a file(not directory)
+            readOnly: true
+          - name: mime-types
+            mountPath: /etc/nginx/mime.types
+            subPath: mime.types  # mount as a file(not directory)
             readOnly: true
           - name: htpasswd
             mountPath: /etc/nginx/.htpasswd


### PR DESCRIPTION
GKEに移設してから「進捗どうですか」等のマークが読み込まれない問題が発生していました。
原因はassets下にあったためnginxから直接配信されるshinchoku-icon.ttfファイルのmime typeがデフォルトのapplication/octet-streamになっていたためと推測されます。