### PR TITLE
20MBまでのファイルをアップロードできるようにする

### DIFF
--- a/shinchokunote/nginx.conf.yaml
+++ b/shinchokunote/nginx.conf.yaml
@@ -24,6 +24,7 @@ data:
       server{
         listen 80;
         server_name shinchoku.net www.shinchoku.net;
+        client_max_body_size 20M;
           
         # Rooting for /public
         location / {
@@ -59,6 +60,7 @@ data:
       server{
         listen 80;
         server_name beta.shinchoku.net;
+        client_max_body_size 20M;
         
         # beta版はbasic認証を設けている
         auth_basic           "進捗ノート βテストにご協力いただきありがとうございます！";


### PR DESCRIPTION
nginxのclient_max_body_sizeがデフォルトだと2MBと小さく、画質高めの画像をアップロードすると413 Entity Too Largeで死ぬので回避
（Twitterに画像をアップロードするのをやめればフロントエンドで解決しそうなので、いずれもとに戻すかも）